### PR TITLE
Updated de-code-product to v2.0.1

### DIFF
--- a/packages/de-code-product/package.json
+++ b/packages/de-code-product/package.json
@@ -11,4 +11,3 @@
   "license": "MIT",
   "gitHead": "a192177f720cb83f9a29ce24e63c25e4d9ed05da"
 }
-

--- a/packages/de-code-product/package.json
+++ b/packages/de-code-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "de-code-product",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "MayaData product design system",
   "main": "css/index.css",
   "scripts": {

--- a/packages/de-code-product/package.json
+++ b/packages/de-code-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "de-code-product",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "De-code product package",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/de-code-product/package.json
+++ b/packages/de-code-product/package.json
@@ -1,7 +1,8 @@
 {
   "name": "de-code-product",
   "version": "2.0.0",
-  "description": "De-code product package",
+  "description": "MayaData product design system",
+  "main": "css/index.css",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build:css": "node-sass --output-style expanded --source-map true --source-map-contents true --precision 6 index.scss -o css/"
@@ -10,3 +11,4 @@
   "license": "MIT",
   "gitHead": "a192177f720cb83f9a29ce24e63c25e4d9ed05da"
 }
+

--- a/packages/de-code/package.json
+++ b/packages/de-code/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@mayadata/de-code",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "De-code css package",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build:css": "node-sass --output-style expanded --source-map true --source-map-contents true --precision 6 index.scss -o css/"
   },
   "dependencies": {
-    "de-code-product": "^1.1.0"
+    "de-code-product": "^2.0.0"
   },
   "author": "MayaData, Inc.",
   "license": "MIT",

--- a/packages/de-code/package.json
+++ b/packages/de-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mayadata/de-code",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "MayaData product design system",
   "main": "css/index.css",
   "scripts": {
@@ -8,7 +8,7 @@
     "build:css": "node-sass --output-style expanded --source-map true --source-map-contents true --precision 6 index.scss -o css/"
   },
   "dependencies": {
-    "de-code-product": "^2.0.0"
+    "de-code-product": "^2.0.1"
   },
   "author": "MayaData, Inc.",
   "license": "MIT",

--- a/packages/de-code/package.json
+++ b/packages/de-code/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@mayadata/de-code",
   "version": "2.0.0",
-  "description": "De-code css package",
+  "description": "MayaData product design system",
+  "main": "css/index.css",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build:css": "node-sass --output-style expanded --source-map true --source-map-contents true --precision 6 index.scss -o css/"


### PR DESCRIPTION
1. Updating `de-code-product` version to v2.0.1 in the GitHub repo.
2. Adding `main` and updating description of the package