### PR TITLE
New terminal modal design added to modal component

### DIFF
--- a/docs/products/colors.mdx
+++ b/docs/products/colors.mdx
@@ -63,4 +63,7 @@ import ColorBlock from './components/colorblock.js'
   <div className="col-sm-3">
     <ColorBlock name={darkgreen} />
   </div>
+  <div className="col-sm-3">
+    <ColorBlock name={black} />
+  </div>
 </div>

--- a/docs/products/modal.mdx
+++ b/docs/products/modal.mdx
@@ -88,3 +88,26 @@ for large modal use className "modal-lg" along with modal className.
   </div>
 </div>
 </Playground>
+
+### Terminal-modal
+
+<Playground>
+<div className="modal" tabIndex="-1" role="dialog">
+  <div className="modal-dialog" role="document">
+    <div className="modal-content terminal">
+      <div className="modal-header d-flex justify-content-between pt-3 pl-3 pr-3 pb-3">
+        <p className="modal-title">Modal title</p>
+        <button type="button" className="btn btn-icon p-0" data-dismiss="modal" aria-label="Close">
+          <i className="dci dci-x"></i>
+        </button>
+      </div>
+      <div className="modal-body p-0 d-flex justify-content-start">
+        <div class="terminal-body p-2">
+          Terminal related Iframe or JSON data can be displayed here 
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</Playground>
+

--- a/docs/style.scss
+++ b/docs/style.scss
@@ -188,3 +188,13 @@
 mark{
   // background-color: $yellow-100;
 }
+
+.modal-content.terminal{
+  .btn-icon{
+    position: unset !important;
+  }
+  .terminal-body{
+    height: 600px;
+    color: white;
+  }
+}

--- a/scss/core/abstracts/_colors.scss
+++ b/scss/core/abstracts/_colors.scss
@@ -12,8 +12,6 @@ $blue-300: #4489F7 !default;
 $blue-400: #276AD4 !default;
 $blue-500: #1263E4 !default;
 $blue-600: #0E4FB6 !default;
-$blue-700: #003AAC !default;
-
 
 // Green color variations
 

--- a/scss/core/abstracts/_variables.scss
+++ b/scss/core/abstracts/_variables.scss
@@ -1021,4 +1021,4 @@ $progress-steps: 10; //this needs to be even.
 
 //modal-terminal
 
-$modal-terminal-headear-background-color: $blue-700;
+$modal-terminal-headear-background-color: $blue-500;


### PR DESCRIPTION
New terminal modal design added to modal component
<img width="1439" alt="Screenshot 2020-09-28 at 12 22 33 PM" src="https://user-images.githubusercontent.com/54272277/94399585-4d0e6800-0185-11eb-9b34-0cee98e857bc.png">
