### PR TITLE
Changed warning color and added text-amber for warning alert

### DIFF
--- a/docs/products/alerts.mdx
+++ b/docs/products/alerts.mdx
@@ -29,7 +29,7 @@ import { Playground, PropsTable } from 'docz'
   This is a danger alert with <a href="#" className="alert-link">an example link</a>. Give it a click if you like.
 </div>
 <div className="alert alert-warning" role="alert">
-  <i class="mi mi-2x mi-alert-triangle-filled text-warning"></i>
+  <i class="mi mi-2x mi-alert-triangle-filled text-amber"></i>
   This is a warning alert with <a href="#" className="alert-link">an example link</a>. Give it a click if you like.
 </div>
 <div className="alert alert-info" role="alert">

--- a/scss/core/abstracts/_colors.scss
+++ b/scss/core/abstracts/_colors.scss
@@ -123,7 +123,7 @@ $danger: $red !default;
 $success: $green !default;
 $gray: $gray !default;
 $error: $red-300 !default;
-$warning: $amber-200 !default;
+$warning: $yellow !default;
 $inactive: $gray-500 !default;
 $info: $darkgreen !default;
 $purple: $purple !default;


### PR DESCRIPTION
Changed warning color and added text-amber for warning alert

Warning color:
<img width="80" alt="Screenshot 2020-10-15 at 12 53 27 PM" src="https://user-images.githubusercontent.com/34312966/96090185-78af8300-0ee5-11eb-8d28-fde6ca6fde62.png">

text-amber in warning alert:
<img width="794" alt="Screenshot 2020-10-15 at 12 53 09 PM" src="https://user-images.githubusercontent.com/34312966/96090220-85cc7200-0ee5-11eb-872f-ac484f571839.png">
