### PR TITLE
Unsetting text alignment for form and it's components

### DIFF
--- a/scss/product/components/_modal.scss
+++ b/scss/product/components/_modal.scss
@@ -155,6 +155,10 @@
   -ms-word-break: break-word;
   word-break: break-word;
   text-align: center;
+
+  form, .form-control, .form-group, .custom-control{
+    text-align: unset;
+  }
 }
 // Footer (for actions)
 .modal-footer {


### PR DESCRIPTION
1. We are aligning all the texts inside `modal-body` to center. So, in this PR we are unsetting text alignment for form and it's components. 