### PR TITLE
Form and button changes

### DIFF
--- a/scss/core/abstracts/_variables.scss
+++ b/scss/core/abstracts/_variables.scss
@@ -397,9 +397,9 @@ $input-padding-x-lg:                    1.1rem !default;
 $input-line-height-lg:                  $input-btn-line-height-lg !default;
 
 $input-bg:                              $white !default;
-$input-disabled-bg:                     $gray-100 !default;
-$input-disabled-border:                 1px solid $gray-400 !default;
-$input-disabled-color:                  $gray-500 !default;
+$input-disabled-bg:                     $gray-400 !default;
+$input-disabled-border:                 1px solid $gray-600 !default;
+$input-disabled-color:                  $gray-600 !default;
 
 $input-color:                           $purple !default;
 $input-border-color:                    $blue-100 !default;

--- a/scss/core/abstracts/mixins/_buttons.scss
+++ b/scss/core/abstracts/mixins/_buttons.scss
@@ -36,6 +36,7 @@
     background-color: $btn-disabled-background;
     color: $btn-disabled-color;
     border: transparent;
+    border: $input-btn-border-width solid $btn-disabled-background;
   }
 
   &.active {

--- a/scss/product/components/_modal.scss
+++ b/scss/product/components/_modal.scss
@@ -157,7 +157,7 @@
   text-align: center;
 
   form, .form-control, .form-group, .custom-control{
-    text-align: unset;
+    text-align: left;
   }
 }
 // Footer (for actions)


### PR DESCRIPTION
1. Form disabled/read-only style change according to the new style guide

Before:
<img width="796" alt="Screenshot 2020-10-28 at 11 46 10 AM" src="https://user-images.githubusercontent.com/34312966/97399687-aa780f00-1913-11eb-97fc-ee878ce1556e.png">

After:
<img width="799" alt="Screenshot 2020-10-28 at 11 45 51 AM" src="https://user-images.githubusercontent.com/34312966/97399702-b19f1d00-1913-11eb-9b3d-8803700a2bf8.png">

2. text aligned left for form elements inside modal

3. Replaced transparent border with the background color for button disabled state to match the height of other buttons