### PR TITLE
Progress bar, card and font-weight changes

### DIFF
--- a/docs/products/colors.mdx
+++ b/docs/products/colors.mdx
@@ -2,7 +2,7 @@
 name: Colors
 menu: Foundation
 ---
-import { blue, gray, skyblue, green, orange, red, yellow, amber, purple, darkgreen, dustygray, black} from '../utils/colors.js'
+import { blue, gray, skyblue, green, orange, red, yellow, amber, purple, darkgreen, dustygray, black, teal} from '../utils/colors.js'
 import ColorBlock from './components/colorblock.js'
 
 # Colors
@@ -28,6 +28,7 @@ import ColorBlock from './components/colorblock.js'
   <div className="col-sm-3 color-base-block bg-purple"></div>
   <div className="col-sm-3 color-base-block bg-link"></div>
   <div className="col-sm-3 color-base-block bg-amber"></div>
+  <div className="col-sm-3 color-base-block bg-teal"></div>
 </div>
 
 ## Palettes
@@ -68,5 +69,8 @@ import ColorBlock from './components/colorblock.js'
   </div>
   <div className="col-sm-3">
     <ColorBlock name={black} />
+  </div>
+  <div className="col-sm-3">
+    <ColorBlock name={teal} />
   </div>
 </div>

--- a/docs/utils/colors.js
+++ b/docs/utils/colors.js
@@ -1,4 +1,4 @@
-// blue, gray, skyblue, green, orange, red, yellow, amber, purple, darkgreen, dustygray, black
+// blue, gray, skyblue, green, orange, red, yellow, amber, purple, darkgreen, dustygray, black, teal
 
 export const blue = [
   {'name':'blue-100', 'hax':'#C3DAFF', 'rgb':''},
@@ -59,4 +59,7 @@ export const dustygray = [
 ];
 export const black = [
   {'name':'black', 'hax':'#000000', 'rgb':''},
+];
+export const teal = [
+  {'name':'teal', 'hax':'#24A4B1', 'rgb':''},
 ];

--- a/scss/core/abstracts/_colors.scss
+++ b/scss/core/abstracts/_colors.scss
@@ -86,6 +86,9 @@ $dustygray: #959595 !default;
 
 $black: #000000 !default;
 
+// Teal
+$teal: #24A4B1 !default;
+
 // Base colors
 $blue:    $blue-500 !default;
 $green:   $green-200 !default;
@@ -130,7 +133,7 @@ $purple: $purple !default;
 $link: $blue-600 !default;
 $offline: $blue-200 !default;
 $disconnected: $gray-700 !default;
-
+$lightblue: $blue-300 !default;
 
 //Color maps
 $theme-colors: () !default;
@@ -156,7 +159,9 @@ $theme-colors: map-merge((
   "yellow": $yellow,
   "darkgreen": $darkgreen,
   "dustygray": $dustygray,
-  "black": $black
+  "black": $black,
+  "teal": $teal,
+  "lightblue": $lightblue
 ), $theme-colors);
 
 $button-colors: () !default;

--- a/scss/core/abstracts/_variables.scss
+++ b/scss/core/abstracts/_variables.scss
@@ -882,15 +882,17 @@ $banner-padding-x:                  1.25rem !default;
 
 $progress-height: 8px !default;
 $progress-font-size: ($font-size-base * 0.75) !default;
-$progress-bg: $white !default;
+$progress-bg: $teal !default;
 $progress-border: 1px solid $primary;
 $progress-border-radius: 0 !default;
 $progress-box-shadow: inset 0 0.1rem 0.1rem rgba($black, 0.1) !default;
 $progress-bar-color: $white !default;
-$progress-bar-bg: theme-color('primary') !default;
+$progress-bar-bg: $red-200 !default;
 $progress-bar-animation-timing: 1s linear infinite !default;
 $progress-bar-transition: width 0.6s ease !default;
 
+$progress-success-progress-bar-background-color: $green-300;
+$progress-failed-border: 1px solid $red-300;
 //loader
 
 $loader-border: 4px solid $gray-100;

--- a/scss/core/tokens/_text.scss
+++ b/scss/core/tokens/_text.scss
@@ -32,6 +32,7 @@
 
 .font-weight-light  { font-weight: $font-weight-light !important; }
 .font-weight-normal { font-weight: $font-weight-normal !important; }
+.font-weight-semi-bold   { font-weight: $font-weight-semi-bold !important; }
 .font-weight-bold   { font-weight: $font-weight-bold !important; }
 .font-weight-black  { font-weight: $font-weight-black !important; }
 .font-italic        { font-style: italic !important; }

--- a/scss/product/components/_card.scss
+++ b/scss/product/components/_card.scss
@@ -161,9 +161,6 @@
       color: inherit;
       text-decoration: none;
     }
-    span {
-      color: $gray-500;
-    }
     &:hover {
       box-shadow: -1px 6px 22px 2px rgba(145, 150, 211, 0.3);
     }

--- a/scss/product/components/_progress.scss
+++ b/scss/product/components/_progress.scss
@@ -11,7 +11,6 @@
 
 .progress {
   background-color: $progress-bg;
-  border: $progress-border;
   border-radius: $progress-border-radius;
   display: flex;
   height: $progress-height;
@@ -32,8 +31,20 @@
     transition-timing-function: cubic-bezier(0.65, 0.05, 0.36, 1);
   }
   
-}
+  &.progress-success {
+    border: 1px solid $primary;
+    border-radius: 10px;
+  
+    .progress-bar {
+      background: $progress-success-progress-bar-background-color;
+    }
 
+  &.failed{
+    border:$progress-failed-border;
+
+  }
+}
+}
 .donut {
   position: sticky;
 }


### PR DESCRIPTION
Progress bar, card, and font-weight changes

1. Removed span color in card-deck 
2. Added `font-weight-semi-bold` class
3. Added `lightblue` color variable in theme color to be used in `text-lightblue`
4. Added new color teal
<img width="217" alt="Screenshot 2020-11-04 at 11 45 31 AM" src="https://user-images.githubusercontent.com/34312966/98076253-f25ae100-1e93-11eb-9900-609066de2498.png">

5. Updated progress bar CSS according to new design
<img width="900" alt="Screenshot 2020-11-04 at 11 43 35 AM" src="https://user-images.githubusercontent.com/34312966/98076302-069ede00-1e94-11eb-8dfe-df455517baa2.png">
