### PR TITLE
Typography and btn-link with underline

### DIFF
--- a/docs/foundation/typography.mdx
+++ b/docs/foundation/typography.mdx
@@ -9,7 +9,6 @@ import { Playground, PropsTable } from 'docz'
 
 ## Font sizes
 
-### Solid
 <Playground>
   <p className="text-xxs">text-xxs</p>
   <p className="text-xs">text-xs</p>
@@ -19,4 +18,43 @@ import { Playground, PropsTable } from 'docz'
   <p className="text-xl">text-xl</p>
   <p className="text-xxl">text-xxl</p>
   <p className="text-xxxl">text-xxxl</p>
+</Playground> 
+
+## Font weights
+
+<Playground>
+  <p className="font-weight-light">Light</p>
+  <p className="font-weight-normal">Normal</p>
+  <p className="font-weight-semi-bold">Semi bold</p>
+  <p className="font-weight-bold">Bold</p>
+  <p className="font-weight-black">Black</p>
+</Playground>
+
+
+## Font styles
+
+<Playground>
+  <p className="font-italic">Italic</p>
+  <p className="text-lowercase">Lowercase</p>
+  <p className="text-uppercase">Uppercase</p>
+  <p className="text-capitalize">Capitalize</p>
+</Playground>
+
+## Text alignments
+
+<Playground>
+<h5>Text justify:</h5>
+<div className="w-4xl bg-blue-outline"><p className="text-justify">Lorem ipsum dolor sit amet</p></div>
+<h5>Text nowrap:</h5>
+<div className="w-4xl bg-blue-outline"><p className="text-nowrap">Lorem ipsum dolor sit amet</p></div>
+<h5>Text truncate:</h5>
+<div className="w-4xl bg-blue-outline"><p className="text-truncate">Lorem ipsum dolor sit amet</p></div>
+<h5>Text wrap:</h5>
+<div className="w-4xl bg-blue-outline"><p className="text-wrap">Lorem ipsum dolor sit amet</p></div>
+<h5>Text left:</h5>
+<div className="w-4xl bg-blue-outline"><p className="text-left">Lorem ipsum dolor sit amet</p></div>
+<h5>Text right:</h5>
+<div className="w-4xl bg-blue-outline"><p className="text-right">Lorem ipsum dolor sit amet</p></div>
+<h5>Text center:</h5>
+<div className="w-4xl bg-blue-outline"><p className="text-center">Lorem ipsum dolor sit amet</p></div>
 </Playground>

--- a/docs/foundation/typography.mdx
+++ b/docs/foundation/typography.mdx
@@ -3,4 +3,20 @@ name: Typography
 menu: Foundation
 ---
 
+import { Playground, PropsTable } from 'docz'
+
 # Typography
+
+## Font sizes
+
+### Solid
+<Playground>
+  <p className="text-xxs">text-xxs</p>
+  <p className="text-xs">text-xs</p>
+  <p className="text-sm">text-sm</p>
+  <p className="text-md">text-md</p>
+  <p className="text-lg">text-lg</p>
+  <p className="text-xl">text-xl</p>
+  <p className="text-xxl">text-xxl</p>
+  <p className="text-xxxl">text-xxxl</p>
+</Playground>

--- a/docs/products/buttons.mdx
+++ b/docs/products/buttons.mdx
@@ -44,6 +44,8 @@ import google from '../../resources/images/workloads/google.svg'
 ### Link
 <Playground>
    <button className="btn btn-link">Button</button>
+   <h5 className="mt-4">Button link with underline:</h5>
+   <button className="btn btn-link link-underline">Button</button>
 </Playground>
 
 ### Icon buttons

--- a/scss/core/abstracts/_variables.scss
+++ b/scss/core/abstracts/_variables.scss
@@ -166,8 +166,9 @@ $font-size-xs: 0.75rem !default;
 $font-size-sm: 0.875rem !default;
 $font-size-md: 1rem !default;
 $font-size-lg: 1.125rem !default;
-$font-size-xl: 1.625rem !default;
-$font-size-xxl: 2rem !default;
+$font-size-xl: 1.375rem !default;
+$font-size-xxl: 1.625rem !default;
+$font-size-xxxl: 2rem !default;
 
 $font-weight-light:           300 !default;
 $font-weight-normal:          400 !default;

--- a/scss/core/tokens/_text.scss
+++ b/scss/core/tokens/_text.scss
@@ -77,6 +77,9 @@
 .text-xxl{
   font-size: $font-size-xxl !important;
 }
+.text-xxxl{
+  font-size: $font-size-xxxl !important;
+}
 
 //line height
 .line-height-normal{

--- a/scss/core/tokens/_text.scss
+++ b/scss/core/tokens/_text.scss
@@ -80,7 +80,9 @@
 .text-xxxl{
   font-size: $font-size-xxxl !important;
 }
-
+.text-inherit{
+  font-size: inherit !important;
+}
 //line height
 .line-height-normal{
   line-height: normal;

--- a/scss/product/components/_buttons.scss
+++ b/scss/product/components/_buttons.scss
@@ -153,6 +153,11 @@ fieldset[disabled] a.btn {
     color: $btn-link-disabled-color;
   }
   // No need for an active state here
+
+  &.link-underline{
+    border-bottom: 1px solid;
+    height: 25px;
+  }
 }
 
 //

--- a/scss/product/components/_modal.scss
+++ b/scss/product/components/_modal.scss
@@ -204,18 +204,18 @@
 
 .modal, .modal-md{
   &.modal-dialog {
-    max-width: 700px;
+    width: 700px;
   }
 }
 .modal-sm{
   &.modal-dialog{
-    max-width: 550px;
+    width: 550px;
   }
 }
 
 .modal-lg{
   &.modal-dialog{
-    max-width: 900px;
+    width: 900px;
   }
 }
 


### PR DESCRIPTION
1. Added btn-link with uinderline:

<img width="877" alt="Screenshot 2020-11-11 at 11 25 32 AM" src="https://user-images.githubusercontent.com/34312966/98774779-b5519a00-2411-11eb-898f-f4b5c8c0af37.png">

2. Added Typography - font sizes, font-weights, font-styles and text alignments:

<img width="887" alt="Screenshot 2020-11-11 at 11 31 26 AM" src="https://user-images.githubusercontent.com/34312966/98774783-b682c700-2411-11eb-95b1-c28d5ef0ab72.png">
<img width="900" alt="Screenshot 2020-11-11 at 12 12 42 PM" src="https://user-images.githubusercontent.com/34312966/98777811-66a6fe80-2417-11eb-840e-1465380118f8.png">
<img width="889" alt="Screenshot 2020-11-11 at 12 12 48 PM" src="https://user-images.githubusercontent.com/34312966/98777820-6b6bb280-2417-11eb-9e64-4d71b1bfc154.png">
<img width="881" alt="Screenshot 2020-11-11 at 12 12 59 PM" src="https://user-images.githubusercontent.com/34312966/98777829-6eff3980-2417-11eb-929d-ee40f01d03c3.png">


3. Changed modal size width from `max-width` to `width`
