### PR TITLE
Section header and list component

### DIFF
--- a/docs/products/list.mdx
+++ b/docs/products/list.mdx
@@ -6,3 +6,36 @@ menu: Components
 import { Playground, PropsTable } from 'docz'
 
 # Lists
+
+<Playground>
+<ul class="list-group">
+    <li class="list-group-item">List item 1</li>
+    <li class="list-group-item active">List item 2</li>
+    <li class="list-group-item">List item 3</li>
+    <li class="list-group-item">List item 4</li>
+</ul>
+</Playground>
+
+### Flush list items
+* Remove borders and border-radius to keep list group items edge-to-edge. Most
+* Useful within other components (e.g., cards).
+
+<Playground>
+<ul class="list-group list-group-flush">
+    <li class="list-group-item">List item 1</li>
+    <li class="list-group-item">List item 2</li>
+    <li class="list-group-item">List item 3</li>
+    <li class="list-group-item">List item 4</li>
+</ul>
+</Playground>
+
+### Numeric list items
+
+<Playground>
+<ul class="list-group numeric-list">
+    <li class="list-group-item"><span class="list-icon">1</span>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</li>
+    <li class="list-group-item"><span class="list-icon">2</span>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</li>
+    <li class="list-group-item"><span class="list-icon">3</span>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</li>
+    <li class="list-group-item"><span class="list-icon">4</span>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</li>
+</ul>
+</Playground>

--- a/docs/style.scss
+++ b/docs/style.scss
@@ -199,3 +199,7 @@ mark{
     color: white;
   }
 }
+
+.divider{
+  border-top: 1px solid ;
+}

--- a/scss/core/abstracts/_variables.scss
+++ b/scss/core/abstracts/_variables.scss
@@ -913,18 +913,13 @@ $list-group-item-padding-x:         1.25rem !default;
 
 $list-group-hover-bg:               $gray-100 !default;
 $list-group-active-color:           $component-active-color !default;
-$list-group-active-bg:              $component-active-bg !default;
+$list-group-active-bg:              $green-200 !default;
 $list-group-active-border-color:    $list-group-active-bg !default;
 
 $list-group-disabled-color:         $gray-600 !default;
 $list-group-disabled-bg:            $list-group-bg !default;
-
-$list-group-action-color:           $gray-600 !default;
-$list-group-action-hover-color:     $list-group-action-color !default;
-
-$list-group-action-active-color:    $body-color !default;
-$list-group-action-active-bg:       $gray-200 !default;
-
+$numeric-list-icon-background-color: $red-100 !default;
+$numeric-list-icon-color: $purple !default;
 
 // Image thumbnails
 
@@ -1052,3 +1047,8 @@ $avatar-box-shadow: 0px 1px 15px rgba($blue-700, .11);
 //modal-terminal
 
 $modal-terminal-headear-background-color: $blue-600;
+
+
+// Divider
+
+$divider-border-color: $blue-100 !default;

--- a/scss/product/components/_forms.scss
+++ b/scss/product/components/_forms.scss
@@ -13,6 +13,7 @@
   background-color: $input-bg;
   background-clip: padding-box;
   border: $input-border-width solid $input-border-color;
+  box-shadow: none; //required for handling firefox required input issue
   // Note: This has no effect on <select>s in some browsers, due to the limited stylability of `<select>`s in CSS.
   @if $enable-rounded {
     // Manually use the if/else instead of the mixin to account for iOS override

--- a/scss/product/components/_headers.scss
+++ b/scss/product/components/_headers.scss
@@ -112,7 +112,8 @@
         }
       }
     .section-header_title__text {
-      font-size: 18px;
+      font-size:  $font-size-xl;
+      font-weight: $font-weight-bold;
     }
   }
 

--- a/scss/product/components/_list-group.scss
+++ b/scss/product/components/_list-group.scss
@@ -11,31 +11,6 @@
   margin-bottom: 0;
 }
 
-
-// Interactive list items
-//
-// Use anchor or button elements instead of `li`s or `div`s to create interactive
-// list items. Includes an extra `.active` modifier class for selected items.
-
-.list-group-item-action {
-  width: 100%; // For `<button>`s (anchors become 100% by default though)
-  color: $list-group-action-color;
-  text-align: inherit; // For `<button>`s (anchors inherit)
-
-  // Hover state
-  @include hover-focus {
-    color: $list-group-action-hover-color;
-    text-decoration: none;
-    background-color: $list-group-hover-bg;
-  }
-
-  &:active {
-    color: $list-group-action-active-color;
-    background-color: $list-group-action-active-bg;
-  }
-}
-
-
 // Individual list items
 //
 // Use on `li`s or `div`s within the `.list-group` parent.
@@ -59,7 +34,6 @@
   }
 
   @include hover-focus {
-    z-index: 1; // Place hover/active items above their siblings for proper border styling
     text-decoration: none;
   }
 
@@ -88,7 +62,7 @@
   .list-group-item {
     border-right: 0;
     border-left: 0;
-    @include border-radius(0);
+    border-radius: 0;
   }
 
   &:first-child {
@@ -112,4 +86,28 @@
 
 @each $color, $value in $theme-colors {
   @include list-group-item-variant($color, theme-color-level($color, -9), theme-color-level($color, 6));
+}
+
+.numeric-list{
+  .list-group-item{
+    display: flex;
+    border: none;
+  }
+}
+// numeric list icon
+.list-icon{
+    background: $numeric-list-icon-background-color;
+    color: $numeric-list-icon-color;
+    font-size: 14px;
+    font-weight: 700;
+    border-radius: 50%;
+    width: 32px;
+    height: 32px;
+    min-width: 32px;
+    min-height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    vertical-align: middle;
+    margin-right: 12px;
 }


### PR DESCRIPTION
1. Changed styling for section header according to new design
<img width="801" alt="Screenshot 2020-11-13 at 3 50 25 PM" src="https://user-images.githubusercontent.com/34312966/99065263-1ec9d800-25cd-11eb-9c40-0ba9eef4b31e.png">


2. Added list component

<img width="897" alt="Screenshot 2020-11-13 at 4 19 56 PM" src="https://user-images.githubusercontent.com/34312966/99065277-26897c80-25cd-11eb-8ee9-599c0382ff28.png">
<img width="881" alt="Screenshot 2020-11-13 at 4 20 03 PM" src="https://user-images.githubusercontent.com/34312966/99065292-2d17f400-25cd-11eb-9cd5-beb8181d9712.png">

3. Fixes required input border issue in firefox browser