### PR TITLE
table z-index change

### DIFF
--- a/scss/core/abstracts/_variables.scss
+++ b/scss/core/abstracts/_variables.scss
@@ -613,7 +613,7 @@ $zindex-modal:                      1070 !default;
 $zindex-popover:                    1080 !default;
 $zindex-tooltip:                    1090 !default;
 $zindex-alert:                      1100 !default;
-
+$zindex-table:                      10 !default; //for scrollable table
 // Navs
 $nav-link-color:                    $gray-600 !default;
 $nav-link-active-color:             $blue-600 !default;

--- a/scss/product/components/_tables.scss
+++ b/scss/product/components/_tables.scss
@@ -264,7 +264,7 @@ table{
   width: 100%;
   overflow: auto;
   position: relative;
-  z-index: $zindex-sticky;
+  z-index: $zindex-table;
   >table {
     position: relative;
     >* {
@@ -272,7 +272,7 @@ table{
         >th {
           &:first-child {
             position: sticky;
-            z-index: $zindex-sticky;
+            z-index: $zindex-table;
             left:0;
             white-space: normal;
             min-width: 200px;
@@ -280,7 +280,7 @@ table{
           }
           &:last-child {
             position: sticky;
-            z-index: $zindex-sticky;
+            z-index: $zindex-table;
             right:0;
             white-space: normal;
             min-width: 50px;
@@ -291,7 +291,7 @@ table{
         >td {
           &:first-child {
             position: sticky;
-            z-index: $zindex-sticky;
+            z-index: $zindex-table;
             left:0;
             white-space: normal;
             background-color: $white;
@@ -301,7 +301,7 @@ table{
           }
           &:last-child {
             position: sticky;
-            z-index: $zindex-sticky;
+            z-index: $zindex-table;
             right:0;
             white-space: normal;
             background-color: $white;


### PR DESCRIPTION
scroll table zindex was high, dropdowns in the same page will go behind the table as we open as the z-index is high. 
issue:
![image](https://user-images.githubusercontent.com/54272336/99511058-cb310300-29ad-11eb-9728-3f3bcc29b0e4.png)
