### PR TITLE
modal lg width alignment issue

### DIFF
--- a/scss/product/components/_modal.scss
+++ b/scss/product/components/_modal.scss
@@ -64,7 +64,6 @@
   position: relative;
   margin: $modal-dialog-margin; // allow clicks to pass through for custom click handling to close modal
   pointer-events: none;
-  max-width: 700px;
 
   &.modal-justify-center {
     display: flex;


### PR DESCRIPTION
**Issue cause -** 
   If we use `modal-lg` , modal pop up is  not aligned in  center

![Screenshot from 2020-11-25 19-19-47](https://user-images.githubusercontent.com/28762224/100237847-7a914b00-2f55-11eb-8e1a-58cfe5f1aa2a.png)




**Fixed:**
  since we are giving width according to modal size `(modal-md, modal-lg, modal-sm 700px,900px,550px respectively)`  so not required in `modal-dialog`


![Screenshot from 2020-11-25 19-36-43](https://user-images.githubusercontent.com/28762224/100237925-94cb2900-2f55-11eb-805f-dd67a87462c9.png)




Signed-off-by: ashishjain <ashish.jain@mayadata.io>