### PR TITLE
table link icon, popover and toggle switch changes

### DIFF
--- a/scss/core/abstracts/_variables.scss
+++ b/scss/core/abstracts/_variables.scss
@@ -309,7 +309,8 @@ $nested-table-head-background: $skyblue-300 !default;
 $nested-table-row-background: $gray-100 !default;
 $nested-table-head-border-color: $blue-100 !default;
 
-
+$table-action_link-color: $purple;
+$table-action_link-disabled-color: $gray-600;
 
 // Buttons + Forms
 //

--- a/scss/product/components/_forms.scss
+++ b/scss/product/components/_forms.scss
@@ -490,8 +490,8 @@ select.form-control-lg {
   position: relative;
   display: inline-block;
   cursor: pointer;
-  width: 55px;
-  height: 30px;
+  width: 40px;
+  height: 20px;
   background-color: $gray-400;
   margin: 0 10px;
   vertical-align: middle;
@@ -502,8 +502,8 @@ select.form-control-lg {
 .slider:before {
   position: absolute;
   content: "";
-  height: 26px;
-  width: 26px;
+  height: 16px;
+  width: 16px;
   left: 2px;
   top: 2px;
   bottom: 0;

--- a/scss/product/components/_popover.scss
+++ b/scss/product/components/_popover.scss
@@ -198,6 +198,7 @@
   text-align: center;
   padding: 10px;
   &.popover-small{
+    font-size: 12px;
     width: $popover-small-size;
     max-width: $popover-small-size;
   	min-width: $popover-small-size;

--- a/scss/product/components/_tables.scss
+++ b/scss/product/components/_tables.scss
@@ -131,6 +131,12 @@ table{
 
 .table-action_link {
   cursor: pointer;
+  color: $table-action_link-color;
+  &.disabled{
+    color: $table-action_link-disabled-color;
+    opacity: 1;
+    pointer-events: unset;
+  }
 }
 
 // Table backgrounds


### PR DESCRIPTION
1. Table link icon:
<img width="207" alt="Screenshot 2020-11-30 at 11 32 41 AM" src="https://user-images.githubusercontent.com/34312966/100574358-de25ca80-32ff-11eb-9328-1b92b7c425f4.png">

Table link icon disabled:
<img width="185" alt="Screenshot 2020-11-30 at 11 33 10 AM" src="https://user-images.githubusercontent.com/34312966/100574387-ea118c80-32ff-11eb-8848-3bdec2aeaa7c.png">

2. Added font-size for popover-small class

3. Toggle switch size changes according to the design
<img width="95" alt="Screenshot 2020-11-30 at 11 44 01 AM" src="https://user-images.githubusercontent.com/34312966/100575136-7bcdc980-3301-11eb-8735-dbca879d9f5c.png">
