### PR TITLE
Added transparent border to btn-link to avoid slight displacement of the content on hover

### DIFF
--- a/scss/product/components/_buttons.scss
+++ b/scss/product/components/_buttons.scss
@@ -130,7 +130,7 @@ fieldset[disabled] a.btn {
   padding: 0 0.1rem;
   vertical-align: unset;
   border-radius: unset;
-
+  border-bottom: 1px solid transparent;
   @include hover {
     color: $link-hover-color;
     background-color: transparent;


### PR DESCRIPTION
Added transparent border to `btn-link` to avoid slight displacement of the content on hover